### PR TITLE
Revert "Bump h11 from 0.14.0 to 0.16.0 in /backend"

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,7 +17,7 @@ emails==0.6
 fastapi==0.115.6
 fastapi-cli==0.0.7
 greenlet==3.1.1
-h11==0.16.0
+h11==0.14.0
 httpcore==1.0.7
 httptools==0.6.4
 httpx==0.28.1


### PR DESCRIPTION
Reverts Ottohesten/fastapi-svelte#1

Caused issue has version has to between 13 and 15